### PR TITLE
Fix release workflow Python version

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.x"
+        python-version: "3.11"
     - name: Install pypa/build
       run: >-
         python3 -m
@@ -29,8 +29,7 @@ jobs:
     - name: Setup Env
       run: |
         python3 -m pip install poetry
-        poetry install
-        poetry add pytest
+        poetry install --with test
 
     - name: Test Build
       run: >-


### PR DESCRIPTION
## Summary\n- Pin the release workflow to Python 3.11 instead of 3.x\n- Prevent GitHub Actions from resolving to Python 3.14, which breaks pandas 2.2.2 builds\n- Preserve the existing test install flow with Installing dependencies from lock file

Package operations: 8 installs, 25 updates, 0 removals

  - Downgrading frozenlist (1.8.0 -> 1.4.1)
  - Downgrading idna (3.11 -> 3.8)
  - Downgrading multidict (6.7.0 -> 6.0.5)
  - Downgrading propcache (0.4.1 -> 0.2.0)
  - Downgrading six (1.17.0 -> 1.16.0)
  - Downgrading aiohappyeyeballs (2.6.1 -> 2.4.0)
  - Downgrading aiosignal (1.4.0 -> 1.3.1)
  - Downgrading attrs (25.4.0 -> 24.2.0)
  - Downgrading jmespath (1.1.0 -> 1.0.1)
  - Downgrading urllib3 (2.6.3 -> 2.2.2)
  - Downgrading yarl (1.22.0 -> 1.17.2)
  - Downgrading aiohttp (3.13.3 -> 3.10.11)
  - Downgrading aioitertools (0.13.0 -> 0.12.0)
  - Downgrading botocore (1.41.5 -> 1.35.7)
  - Downgrading pycparser (3.0 -> 2.22)
  - Downgrading wrapt (1.17.3 -> 1.16.0)
  - Downgrading aiobotocore (2.26.0 -> 2.14.0)
  - Downgrading cffi (2.0.0 -> 1.17.1)
  - Installing docutils (0.21.2)
  - Downgrading fsspec (2024.12.0 -> 2024.9.0)
  - Installing iniconfig (2.0.0)
  - Installing nh3 (0.2.18)
  - Downgrading numpy (2.4.1 -> 2.1.1)
  - Downgrading packaging (25.0 -> 24.1)
  - Installing pluggy (1.5.0)
  - Downgrading pygments (2.19.2 -> 2.18.0)
  - Downgrading pytz (2025.2 -> 2024.1)
  - Installing tzdata (2024.1)
  - Downgrading cryptography (46.0.5 -> 43.0.1)
  - Installing pandas (2.2.2)
  - Installing pytest (8.3.2)
  - Installing readme-renderer (44.0)
  - Downgrading s3fs (2024.12.0 -> 2024.9.0)

Installing the current project: fsspec-encrypted (0.0.0)\n\n## Why\nThe open Dependabot PRs are blocked by the distribution build job, which currently fails when the workflow resolves Python 3.x to 3.14. Pinning to 3.11 restores a compatible build environment and unblocks dependency updates.\n\n## Validation\n- Reviewed failing CI logs\n- Confirmed failure occurs in pandas compilation under Python 3.14\n- Verified workflow diff locally